### PR TITLE
fix:  [TR-422] add first_name and last_name to current_user service response

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :document_number
+  attributes :id, :email, :document_number, :first_name, :last_name
 end


### PR DESCRIPTION
## JIRA Card

[TR-422 Michelle - Error: Información incompleta para el GET de Usuario](https://widergy.atlassian.net/browse/TR-422?atlOrigin=eyJpIjoiOTEyYzU0Njc5ZGFhNGQ4MGI0NWYyNjFiN2Y3YWFkNjgiLCJwIjoiaiJ9) 👈

## Summary

Se solicita agregar la información de first_name y last_name a la salida del servicio current_user, para eso se agregan ambos atributos al serializador.

## Screenshots

**ANTES**

![current_user_response_before](https://github.com/michellevillemor/Training-Rails-UGUITO-API-Bootstrap/assets/168744627/d101a7b3-f54f-44cd-9736-ee9a46629241)

**DESPUÉS**
![current_user_response_after](https://github.com/michellevillemor/Training-Rails-UGUITO-API-Bootstrap/assets/168744627/acaaf4ac-9ce3-4efc-a781-9ac091b3e520)

![current_user_response_after_north](https://github.com/michellevillemor/Training-Rails-UGUITO-API-Bootstrap/assets/168744627/8cd19df6-f34f-4735-a4a6-2176698350b9)


## Test Cases

Registrar un usuario en Postman, iniciar una nueva sesión y pegarle al endpoint get users/current como se ve en las imágenes anexadas.

![current_user_test](https://github.com/michellevillemor/Training-Rails-UGUITO-API-Bootstrap/assets/168744627/fe954004-6f2e-4804-89bf-977b341f9f77)

![Captura desde 2024-05-09 17-14-47](https://github.com/michellevillemor/Training-Rails-UGUITO-API-Bootstrap/assets/168744627/7a6c78cd-bba4-47ef-a924-79fa0d95506a)
